### PR TITLE
Changed the tag name for publishing the config and views files from laravel-forms-config and laravel-forms-views to forms-config and forms-views respectively. Also changed the package name from laravel-forms to forms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ composer require fuelviews/laravel-forms
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --tag="laravel-forms-config"
+php artisan vendor:publish --tag="forms-config"
 ```
 
 This is the contents of the published config file:
@@ -125,7 +125,7 @@ return [
 Optionally, you can publish the views using
 
 ```bash
-php artisan vendor:publish --tag="laravel-forms-views"
+php artisan vendor:publish --tag="forms-views"
 ```
 
 ### Register Middleware

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -19,9 +19,9 @@ class FormsServiceProvider extends PackageServiceProvider
     public function configurePackage(Package $package): void
     {
         $package
-            ->name('laravel-forms')
+            ->name('forms')
             ->hasConfigFile('forms')
-            ->hasViews('laravel-forms');
+            ->hasViews('forms');
     }
 
     public function bootingPackage(): void


### PR DESCRIPTION
Aims to streamline the naming conventions within our Laravel project by updating the tag names and package names related to the configuration and views files.

Specifically, it changes the tag name for publishing the config file from "laravel-forms-config" to "forms-config" and the tag name for publishing the views from "laravel-forms-views" to "forms-views". Additionally, the package name is updated from "laravel-forms" to "forms" for consistency.

These changes simplify the naming conventions, making it more intuitive and cohesive within the project structure. This enhancement improves clarity and maintainability for developers working on the project, ensuring a smoother development experience.