### PR TITLE
Changed the route name from 'form.validate' to 'forms.validate' in the FormsServiceProvider.php file to maintain consistency with the route prefix.

### DIFF
--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -58,7 +58,7 @@ class FormsServiceProvider extends PackageServiceProvider
     public function registeringPackage(): void
     {
         Route::prefix('forms')->group(function () {
-            Route::post('/submit', [FormsSubmitController::class, 'handleSubmit'])->name('form.validate');
+            Route::post('/submit', [FormsSubmitController::class, 'handleSubmit'])->name('forms.validate');
             Route::get('/thank-you', function () {
                 return view('forms::components.thank-you');
             })->name('thank-you');


### PR DESCRIPTION
Updates the route name from 'form.validate' to 'forms.validate' in the FormsServiceProvider.php file. This change ensures consistency with the route prefix 'forms' and maintains a cohesive naming convention throughout the project. By aligning the route name with the route prefix, the codebase becomes more organized and easier to navigate for developers working on the project. This simple adjustment enhances the clarity and maintainability of the codebase.